### PR TITLE
adafruit_bme680.py: Fix compensation of pressure values

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -189,8 +189,8 @@ class Adafruit_BME680:
         var2 = (var2 * self._pressure_calibration[5]) / 4
         var2 = var2 + (var1 * self._pressure_calibration[4] * 2)
         var2 = (var2 / 4) + (self._pressure_calibration[3] * 65536)
-        var1 = ((var1 / 4) * (var1 / 4)) / 8192
-        var1 = (((var1 * self._pressure_calibration[2] * 32) / 8) +
+        var1 = (((((var1 / 4) * (var1 / 4)) / 8192) *
+                (self._pressure_calibration[2] * 32) / 8) +
                 ((self._pressure_calibration[1] * var1) / 2))
         var1 = var1 / 262144
         var1 = ((32768 + var1) * self._pressure_calibration[0]) / 32768

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -190,7 +190,7 @@ class Adafruit_BME680:
         var2 = var2 + (var1 * self._pressure_calibration[4] * 2)
         var2 = (var2 / 4) + (self._pressure_calibration[3] * 65536)
         var1 = (((((var1 / 4) * (var1 / 4)) / 8192) *
-                (self._pressure_calibration[2] * 32) / 8) +
+                 (self._pressure_calibration[2] * 32) / 8) +
                 ((self._pressure_calibration[1] * var1) / 2))
         var1 = var1 / 262144
         var1 = ((32768 + var1) * self._pressure_calibration[0]) / 32768


### PR DESCRIPTION
Compared the ot reference code, one expression in the lengthy calculation was split in two lines. 
Since a previous interim value was used in the expression twice and replaced by the first 
part of the split expression, the overall result was different to the reference code. The resulting
pressure was not that different, 10 hPa at 1000hPa absolute value, but clearly outside of the
spec with 1hPa absolute pressure error.