### PR TITLE
Add SPI Interface for BME680

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -324,7 +324,7 @@ class Adafruit_BME680_I2C(Adafruit_BME680):
           will be from the previous reading."""
     def __init__(self, i2c, address=0x77, debug=False, *, refresh_rate=10):
         """Initialize the I2C device at the 'address' given"""
-        import adafruit_bus_device.i2c_device as i2c_device
+        from adafruit_bus_device import i2c_device
         self._i2c = i2c_device.I2CDevice(i2c, address)
         self._debug = debug
         super().__init__(refresh_rate=refresh_rate)

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -351,12 +351,21 @@ class Adafruit_BME680_I2C(Adafruit_BME680):
                 print("\t$%02X <= %s" % (values[0], [hex(i) for i in values[1:]]))
 
 class Adafruit_BME680_SPI(Adafruit_BME680):
-    """Driver for BME680 connected over SPI.  Default clock rate is 100000 but can be changed with
-      'baudrate'"""
-    def __init__(self, spi, cs, baudrate=100000):
+    """Driver for SPI connected BME680.
+
+        :param busio.SPI spi: SPI device
+        :param digitalio.DigitalInOut cs: Chip Select
+        :param bool debug: Print debug statements when True.
+        :param int baudrate: Clock rate, default is 100000
+        :param int refresh_rate: Maximum number of readings per second. Faster property reads
+          will be from the previous reading.
+      """
+
+    def __init__(self, spi, cs, baudrate=100000, debug=False, *, refresh_rate=10):
         from adafruit_bus_device import spi_device
         self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)
-        super().__init__()
+        self._debug = debug
+        super().__init__(refresh_rate=refresh_rate)
 
     def _read(self, register, length):
         register = (register | 0x80) & 0xFF  # Read single, bit 7 high.
@@ -364,6 +373,8 @@ class Adafruit_BME680_SPI(Adafruit_BME680):
             spi.write(bytearray([register]))  #pylint: disable=no-member
             result = bytearray(length)
             spi.readinto(result)              #pylint: disable=no-member
+            if self._debug:
+                print("\t$%02X => %s" % (register, [hex(i) for i in result]))
             return result
 
     def _write(self, register, values):
@@ -374,3 +385,5 @@ class Adafruit_BME680_SPI(Adafruit_BME680):
                 buffer[2 * i] = register + i
                 buffer[2 * i + 1] = value & 0xFF
             spi.write(buffer) #pylint: disable=no-member
+            if self._debug:
+                print("\t$%02X <= %s" % (values[0], [hex(i) for i in values[1:]]))

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -401,4 +401,4 @@ class Adafruit_BME680_SPI(Adafruit_BME680):
         spi_mem_page = 0x00
         if register < 0x80:
             spi_mem_page = 0x10
-        self._write(_BME680_REG_STATUS, spi_mem_page)
+        self._write(_BME680_REG_STATUS, [spi_mem_page])


### PR DESCRIPTION
Addresses issues #10 (SPI not implemented)

I copied the SPI interface from the BME280 library and only slightly modified it.

I haven't tested this, as I don't have a BME680.  It would be great is someone with access to a BME680 could give it a try.