### PR TITLE
Fix filter_size setter bug

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -188,7 +188,7 @@ class Adafruit_BME680:
     @filter_size.setter
     def filter_size(self, size):
         if size in _BME680_FILTERSIZES:
-            self._filter = _BME680_FILTERSIZES[size]
+            self._filter = _BME680_FILTERSIZES.index(size)
         else:
             raise RuntimeError("Invalid size")
 


### PR DESCRIPTION
self._filter was incorrectly being set with the value of _BME680_FILTERSIZES at the index `size` instead of the index of that size in the sizes list.

Fixes #23 