### PR TITLE
Added temperature offset

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -146,7 +146,6 @@ class Adafruit_BME680:
         """Check the BME680 was found, read the coefficients and enable the sensor for continuous
            reads."""
 
-
         self._write(_BME680_REG_SOFTRESET, [0xB6])
         time.sleep(0.005)
 

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -142,9 +142,11 @@ class Adafruit_BME680:
        :param int refresh_rate: Maximum number of readings per second. Faster property reads
          will be from the previous reading."""
 
-    def __init__(self, *, refresh_rate=10):
+    def __init__(self, *, refresh_rate=10, temp_offset=5):
         """Check the BME680 was found, read the coefficients and enable the sensor for continuous
            reads."""
+
+
         self._write(_BME680_REG_SOFTRESET, [0xB6])
         time.sleep(0.005)
 
@@ -177,6 +179,9 @@ class Adafruit_BME680:
 
         self._last_reading = 0
         self._min_refresh_time = 1 / refresh_rate
+
+        # Set up temperature offset
+        self.temp_offset = temp_offset
 
     @property
     def pressure_oversample(self):
@@ -231,7 +236,7 @@ class Adafruit_BME680:
         """The compensated temperature in degrees celsius."""
         self._perform_reading()
         calc_temp = ((self._t_fine * 5) + 128) / 256
-        return calc_temp / 100
+        return (calc_temp / 100) - self.temp_offset
 
     @property
     def pressure(self):

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -142,10 +142,9 @@ class Adafruit_BME680:
        :param int refresh_rate: Maximum number of readings per second. Faster property reads
          will be from the previous reading."""
 
-    def __init__(self, *, refresh_rate=10, temp_offset=5):
+    def __init__(self, *, refresh_rate=10):
         """Check the BME680 was found, read the coefficients and enable the sensor for continuous
            reads."""
-
         self._write(_BME680_REG_SOFTRESET, [0xB6])
         time.sleep(0.005)
 
@@ -178,9 +177,6 @@ class Adafruit_BME680:
 
         self._last_reading = 0
         self._min_refresh_time = 1 / refresh_rate
-
-        # Set up temperature offset
-        self.temp_offset = temp_offset
 
     @property
     def pressure_oversample(self):
@@ -235,7 +231,7 @@ class Adafruit_BME680:
         """The compensated temperature in degrees celsius."""
         self._perform_reading()
         calc_temp = ((self._t_fine * 5) + 128) / 256
-        return (calc_temp / 100) - self.temp_offset
+        return calc_temp / 100
 
     @property
     def pressure(self):

--- a/examples/bme680_simpletest.py
+++ b/examples/bme680_simpletest.py
@@ -10,10 +10,13 @@ bme680 = adafruit_bme680.Adafruit_BME680_I2C(i2c, debug=False)
 # change this to match the location's pressure (hPa) at sea level
 bme680.sea_level_pressure = 1013.25
 
+# You will usually have to add an offset to account for the temperature of
+# the sensor. This is usually around 5 degrees but varies by use. Use a
+# separate temperature sensor to calibrate this one.
+temperature_offset = -5
+
 while True:
-    # You will usually have to add an offset to account for the temperature of
-    # the sensor. This is usually around 5 degrees.
-    print("\nTemperature: %0.1f C" % bme680.temperature - 5)
+    print("\nTemperature: %0.1f C" % bme680.temperature + temperature_offset)
     print("Gas: %d ohm" % bme680.gas)
     print("Humidity: %0.1f %%" % bme680.humidity)
     print("Pressure: %0.3f hPa" % bme680.pressure)

--- a/examples/bme680_simpletest.py
+++ b/examples/bme680_simpletest.py
@@ -11,7 +11,9 @@ bme680 = adafruit_bme680.Adafruit_BME680_I2C(i2c, debug=False)
 bme680.sea_level_pressure = 1013.25
 
 while True:
-    print("\nTemperature: %0.1f C" % bme680.temperature)
+    # You will usually have to add an offset to account for the temperature of
+    # the sensor. This is usually around 5 degrees.
+    print("\nTemperature: %0.1f C" % bme680.temperature - 5)
     print("Gas: %d ohm" % bme680.gas)
     print("Humidity: %0.1f %%" % bme680.humidity)
     print("Pressure: %0.3f hPa" % bme680.pressure)


### PR DESCRIPTION
The BME680's sensor almost always measures 5 degrees C hotter than the temperature actually is due to heat created by the sensor itself. Other libraries also have this offset set to 5 degrees. This fixes part of #29 