### PR TITLE
fix simpletest

### DIFF
--- a/examples/bme680_simpletest.py
+++ b/examples/bme680_simpletest.py
@@ -16,7 +16,7 @@ bme680.sea_level_pressure = 1013.25
 temperature_offset = -5
 
 while True:
-    print("\nTemperature: %0.1f C" % bme680.temperature + temperature_offset)
+    print("\nTemperature: %0.1f C" % (bme680.temperature + temperature_offset))
     print("Gas: %d ohm" % bme680.gas)
     print("Humidity: %0.1f %%" % bme680.humidity)
     print("Pressure: %0.3f hPa" % bme680.pressure)


### PR DESCRIPTION
I tried the bme680_simpletest on both a grandcentral_m4 and on an unepectedmaker_feathers2 and had this same error.

```
Press any key to enter the REPL. Use CTRL-D to reload.
Adafruit CircuitPython 6.0.0-rc.0 on 2020-10-16; Adafruit Grand Central M4 Express with samd51p20
>>> import bme680_simpletest
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "bme680_simpletest.py", line 19, in <module>
TypeError: can't convert 'int' object to str implicitly
>>> 
```

adding parentheses to the line 19 fixes it and it now works on both boards.
