### PR TITLE
 Add relative_humidity property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Usage Example
 	while True:
 	    print("\nTemperature: %0.1f C" % bme680.temperature)
 	    print("Gas: %d ohm" % bme680.gas)
-	    print("Humidity: %0.1f %%" % bme680.humidity)
+	    print("Humidity: %0.1f %%" % bme680.relative_humidity)
 	    print("Pressure: %0.3f hPa" % bme680.pressure)
 	    print("Altitude = %0.2f meters" % bme680.altitude)
 

--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -261,6 +261,11 @@ class Adafruit_BME680:
         return calc_pres / 100
 
     @property
+    def relative_humidity(self):
+        """The relative humidity in RH %"""
+        return self.humidity
+
+    @property
     def humidity(self):
         """The relative humidity in RH %"""
         self._perform_reading()

--- a/examples/bme680_simpletest.py
+++ b/examples/bme680_simpletest.py
@@ -18,7 +18,7 @@ temperature_offset = -5
 while True:
     print("\nTemperature: %0.1f C" % (bme680.temperature + temperature_offset))
     print("Gas: %d ohm" % bme680.gas)
-    print("Humidity: %0.1f %%" % bme680.humidity)
+    print("Humidity: %0.1f %%" % bme680.relative_humidity)
     print("Pressure: %0.3f hPa" % bme680.pressure)
     print("Altitude = %0.2f meters" % bme680.altitude)
 


### PR DESCRIPTION
Same change as in [https://github.com/adafruit/Adafruit_CircuitPython_BME280/pull/40](https://github.com/adafruit/Adafruit_CircuitPython_BME280/pull/40):

Almost all Adafruit libraries with a humidity sensor use relative_humidity as the name of the property for sensor humidity:
SHT31D, Si7021, HTU21D, AM2320, HTS221, AHTx0, and also now BME280.

This PR adds a relative_humidity property to BME680 (which simply accesses the humidity property) to normalize the API and allow users to remove conditional processing in environments where different humidity sensors may be used.

This has been tested on an Adafruit BME680 (STEMMA QT version) running the library's simpletest.py code, modified to access the `.relative_humidity` property.

Test environment:
Adafruit CircuitPython 6.0.0 on 2020-11-16; Adafruit Feather M4 Express with samd51j19