### PR TITLE
It appears that relative was removed and is now just humidity

### DIFF
--- a/examples/bme680_simpletest.py
+++ b/examples/bme680_simpletest.py
@@ -18,7 +18,7 @@ temperature_offset = -5
 while True:
     print("\nTemperature: %0.1f C" % (bme680.temperature + temperature_offset))
     print("Gas: %d ohm" % bme680.gas)
-    print("Humidity: %0.1f %%" % bme680.relative_humidity)
+    print("Humidity: %0.1f %%" % bme680.humidity)
     print("Pressure: %0.3f hPa" % bme680.pressure)
     print("Altitude = %0.2f meters" % bme680.altitude)
 


### PR DESCRIPTION
if I'm following this correctly from here:
https://adafruit.github.io/Adafruit_BME680/html/class_adafruit___b_m_e680.html#a2fd214a02735b0e1c80aabf63203410b

It appears that relative_humidity should actually be just humidity.