### PR TITLE
Add SPI example

### DIFF
--- a/examples/bme680_spi.py
+++ b/examples/bme680_spi.py
@@ -1,0 +1,27 @@
+import time
+import board
+import digitalio
+from busio import SPI
+import adafruit_bme680
+
+# Create library object using our Bus SPI port
+cs = digitalio.DigitalInOut(board.D10)
+spi = SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+bme680 = adafruit_bme680.Adafruit_BME680_SPI(spi, cs)
+
+# change this to match the location's pressure (hPa) at sea level
+bme680.sea_level_pressure = 1013.25
+
+# You will usually have to add an offset to account for the temperature of
+# the sensor. This is usually around 5 degrees but varies by use. Use a
+# separate temperature sensor to calibrate this one.
+temperature_offset = -5
+
+while True:
+    print("\nTemperature: %0.1f C" % (bme680.temperature + temperature_offset))
+    print("Gas: %d ohm" % bme680.gas)
+    print("Humidity: %0.1f %%" % bme680.relative_humidity)
+    print("Pressure: %0.3f hPa" % bme680.pressure)
+    print("Altitude = %0.2f meters" % bme680.altitude)
+
+    time.sleep(1)


### PR DESCRIPTION
For #37 

Adds a simple SPI example.

```python
Adafruit CircuitPython 6.1.0 on 2021-01-21; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import bme680_spi

Temperature: 24.0 C
Gas: 23562 ohm
Humidity: 31.7 %
Pressure: 1010.694 hPa
Altitude = 21.31 meters

Temperature: 24.0 C
Gas: 12980 ohm
Humidity: 31.7 %
Pressure: 1010.698 hPa
Altitude = 21.28 meters
```

![test](https://user-images.githubusercontent.com/8755041/107069447-d880b100-6796-11eb-9e04-bcc6c05f7893.jpg)
