### PR TITLE
Add license to example

### DIFF
--- a/examples/bme680_spi.py
+++ b/examples/bme680_spi.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Carter Nelson for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
 import time
 import board
 import digitalio


### PR DESCRIPTION
For #39. Simple edit to add license banner.