### PR TITLE
Use correct value to compute gas resistance

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -312,7 +312,7 @@ class Adafruit_BME680:
             var2 = self._adc_gas - 512
             var2 *= 3
             var2 = 4096 + var2
-            calc_gas_res = (1000 * var1) / var2
+            calc_gas_res = (10000 * var1) / var2
             calc_gas_res = calc_gas_res * 100
         else:
             var1 = (


### PR DESCRIPTION
This code is supposed to be a 1:1 translation from Bosch C library https://github.com/boschsensortec/BME68x-Sensor-API/blob/6dab330cb5727006d5046f9eebf357f8909c0ef6/bme68x.c#L971.

There they do:
```C
    /* multiplying 10000 then dividing then multiplying by 100 instead of multiplying by 1000000 to prevent overflow */
    calc_gas_res = (UINT32_C(10000) * var1) / (uint32_t)var2;
    calc_gas_res = calc_gas_res * 100;
```

With the current code resistance is off by a factor of 10