### PR TITLE
Add optional dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-dynamic = ["dependencies"]
+dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
 py-modules = ["adafruit_bme680"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+optional-dependencies = {optional = {file = ["optional_requirements.txt"]}}


### PR DESCRIPTION
Added optional dependencies to `pyproject.toml`, which aren't currently used now but this format is consistent across the other libraries.  This will make adabot patching more reliable, at least, should that be needed.

Fixes #57