### PR TITLE
fix precommit copyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 Justin Myers for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+# SPDX-FileCopyrightText: 2024 Justin Myers
 #
 # SPDX-License-Identifier: Unlicense
 


### PR DESCRIPTION
This applies the changes that were mentioned here: https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/pull/134#pullrequestreview-1956593962 

I missed that before merging #70 