### PR TITLE
Fix timeout error in adafruit_bme680.py

### DIFF
--- a/adafruit_bme680.py
+++ b/adafruit_bme680.py
@@ -390,7 +390,7 @@ class Adafruit_BME680:
             data = self._read(_BME680_REG_MEAS_STATUS, 17)
             new_data = data[0] & 0x80 != 0
             time.sleep(0.005)
-            if start_time >= time.monotonic() - 3.0:
+            if time.monotonic() - start_time >= 3.0:
                 raise RuntimeError("Timeout while reading sensor data")
         self._last_reading = time.monotonic()
 


### PR DESCRIPTION
This fixes #76.

Line 393 of the library adafruit_bme680.py is written,

if start_time >= time.monotonic() - 3.0:
                raise RuntimeError("Timeout while reading sensor data")

However, this is always going to return true and raise a Runtime Error regardless of your timing rate. This commit replaces line of code with the inverse of that, which is looking at the difference between the time.monotonic (the overall time) and the start_time (when you are looking at a new sensor data):

if time.monotonic() - start_time >= 3.0:
                raise RuntimeError("Timeout while reading sensor data")